### PR TITLE
:rocket: feat: Upgrade Makefile for better compability with manpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
 CFLAGS = -Wall -O3 -flto
-PREFIX = /usr/local
-MANDIR = ${PREFIX}/share/man/man1
+BIN = /usr/local/bin
+
+# This should get all the possible man's path
+# And split the char ':' into a new line
+MANPATH = $(shell manpath | tr ':' '\n')
 
 OBJS=fastcompmgr.o comp_rect.o
 
@@ -14,13 +17,29 @@ fastcompmgr: $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
 
 install: fastcompmgr
-	@cp -t ${PREFIX}/bin fastcompmgr
-	@[ -d "${MANDIR}" ] \
-	  && cp -t "${MANDIR}" fastcompmgr.1
+	@echo "[=] Installing fastcompmgr"
+	@cp -t ${BIN} fastcompmgr
+	@echo "[+] fastcompmgr copied to bin!"
+	@for dir in $(MANPATH); do \
+		MANDIR=$$(find "$$dir" -type d -path "*/man/man1"); \
+		if [ -n "$$MANDIR" ]; then \
+			echo "[=] Creating fastcompmgr man: $$MANDIR"; \
+			cp -t "$$MANDIR" fastcompmgr.1; \
+			echo "[+] fastcompmgr man created!"; \
+			break; \
+		fi \
+	done
+	@echo "[!] fastcompmgr sucessfully installed!"
 
 uninstall:
-	@rm -f ${PREFIX}/fastcompmgr
-	@rm -f ${MANDIR}/fastcompmgr.1
+	@rm -f ${BIN}/fastcompmgr
+	@for dir in $(MANPATH); do \
+		MANDIR=$$(find "$$dir" -type d -path "*/man/man1"); \
+		if [ -n "$$MANDIR" ]; then \
+			rm -f "$${MANDIR}/fastcompmgr.1"; \
+			break; \
+		fi \
+	done
 
 clean:
 	rm -f $(OBJS) fastcompmgr


### PR DESCRIPTION
# Hello folks!
I'm just sending this changes to fix a little problem I had when building the project from source.
**Looks like we were using hard-coded path values for man1...** :thinking: 
What happens is, **in some machines the man paths may vary** (in my case, for example, it is located at `/usr/share/man`).

So I added some logic to try to dynamically find the `man1` file in our system :mag: 
Now it looks just great, and it's no longer breaking in my system when building from source! :tada: _I hope that works in your computer as well haha_

So, what I'm doing is getting the man's path variable with the command `manpath`. This command will generate a simple PATH string like this: `/usr/local/man:/usr/local/share/man:/usr/share/man`. So I split it by `:` and try to find the correct directory inside each path. Then, set the variable, and do all the stuff...

**That's it! :rocket:** 