### PR TITLE
Improve CFLAGS handling and use LDFLAGS if exported.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
-CFLAGS = -Wall -O3 -flto -fno-plt -pipe
+CFLAGS = -Wall -O2 -flto -fno-plt -pipe
 LDFLAGS = -flto -Wl,--sort-common -Wl,--as-needed -Wl,-z,now -Wl,-z,pack-relative-relocs
 PREFIX = /usr/local
 MANDIR = ${PREFIX}/share/man/man1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
 CFLAGS = -Wall -O3 -flto -fno-plt -pipe
-LDFLAGS = -Wl,-O1 -Wl,--sort-common -Wl,--as-needed
+LDFLAGS = -flto -Wl,--sort-common -Wl,--as-needed
 PREFIX = /usr/local
 MANDIR = ${PREFIX}/share/man/man1
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
-CFLAGS = -Wall -O3 -flto
+CFLAGS = -Wall -O3 -flto -fno-plt -pipe
+LDFLAGS = -Wl,-O1 -Wl,--sort-common -Wl,--as-needed
 PREFIX = /usr/local
 MANDIR = ${PREFIX}/share/man/man1
 
@@ -11,7 +12,7 @@ OBJS=fastcompmgr.o comp_rect.o cm-root.o cm-global.o cm-util.o cm-window.o cm-ev
 	$(CC) $(CFLAGS) $(INCS) -c $*.c
 
 fastcompmgr: $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
 install: fastcompmgr
 	@mkdir -p "${PREFIX}/bin"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
 CFLAGS = -Wall -O3 -flto -fno-plt -pipe
-LDFLAGS = -flto -Wl,--sort-common -Wl,--as-needed
+LDFLAGS = -flto -Wl,--sort-common -Wl,--as-needed -Wl,-z,now -Wl,-z,pack-relative-relocs
 PREFIX = /usr/local
 MANDIR = ${PREFIX}/share/man/man1
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PACKAGES = x11 xcomposite xfixes xdamage xrender
 LIBS = `pkg-config --libs ${PACKAGES}` -lm
 INCS = `pkg-config --cflags ${PACKAGES}`
-CFLAGS = -Wall -O2 -flto -fno-plt -pipe
-LDFLAGS = -flto -Wl,--sort-common -Wl,--as-needed -Wl,-z,now -Wl,-z,pack-relative-relocs
+CFLAGS ?= -O2 -flto -pipe
+CFLAGS += -Wall -fno-plt
 PREFIX = /usr/local
 MANDIR = ${PREFIX}/share/man/man1
 


### PR DESCRIPTION
This PR improves the handling of CFLAGS and LDFLAGS in the Makefile.

Changelog (REVISED) :

- LDFLAGS variable used if exported
- CFLAGS are exported and appended if not exported, otherwise only some CFLAGS are appended
- `-O2` is used instead of `-O3`, as the latter can sometimes cause a regression in performance and shouldn't be used in performance-critical applications. See [this](https://github.com/tycho-kirchner/fastcompmgr/pull/23#issuecomment-3839169388) and [this](https://github.com/tycho-kirchner/fastcompmgr/pull/23#issuecomment-3840974238)

For more details about the changes, see [this comment](https://github.com/tycho-kirchner/fastcompmgr/pull/23#issuecomment-3943869097)