### PR TITLE
README: Mention that the libxext dependency of Xcompmgr isn't required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ $ fastcompmgr -o 0.4 -r 12 -c -C &  pid=$!; sleep 4; \
 ## Installation
 If you're lazy, just grab the binary from the [release page](https://github.com/tycho-kirchner/fastcompmgr/releases).
 
-Otherwise, build dependencies are the same as for xcompmgr (except `libxext`):
-
+Otherwise, install the development versions of the following libraries:
 ### Dependencies:
 
 * libx11


### PR DESCRIPTION
The original phrase implied that the dependencies of fastcompmgr are the same as xcompmgr, whereas I found that `libxext` isn't required.

`xcompmgr`:
```
❯ readelf -d /usr/sbin/xcompmgr | grep "NEEDED"
 0x0000000000000001 (NEEDED)             Shared library: [libXcomposite.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libXdamage.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libXfixes.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libXrender.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libX11.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libXext.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
```
`fastcompmgr`:
```
❯ readelf -d /usr/sbin/fastcompmgr | grep "NEEDED"
 0x0000000000000001 (NEEDED)             Shared library: [libXcomposite.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libXdamage.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libXfixes.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libXrender.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libX11.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
```