### PR TITLE
Makefile: Use `install` instead of `cp` for better control over file permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ fastcompmgr: $(OBJS)
 
 install: fastcompmgr
 	@mkdir -p "${PREFIX}/bin"
-	@cp fastcompmgr "${PREFIX}/bin"
+	@install -m755 fastcompmgr "${PREFIX}/bin"
 	@mkdir -p "${MANDIR}"
-	@cp fastcompmgr.1 "${MANDIR}"
+	@install -m644 fastcompmgr.1 "${MANDIR}"
 
 uninstall:
 	@rm -f "${PREFIX}/bin/fastcompmgr"


### PR DESCRIPTION
Hi!

This commit changes the behaviour of the `make install` command by replacing the usage of `cp` with `install`.

This was done to make sure the files are copied with the correct permissions. In case you didn't know, but `install` is actually preferred for packaging.

This should work on BSD, behaves properly for me on Arch Linux.

Thanks!