### PR TITLE
Avoid BadRegion spam for destroyed fading windows

### DIFF
--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -1093,7 +1093,7 @@ paint_all(Display *dpy, XserverRegion region) {
       win_extents(dpy, w);
     }
 
-    if (!w->border_size) {
+    if (!w->border_size && !w->destroyed) {
       w->border_size = border_size (dpy, w);
     }
 
@@ -1169,7 +1169,9 @@ paint_all(Display *dpy, XserverRegion region) {
       // 2024-11-26: Without the next two lines, the Microsoft-Teams screen-share
       // window has a broken frame instead of a shadow, with a "startup-frozen"
       // picture. Inspired by xcompmgr's commit 5a7d139f (2012-08-11).
-      XFixesIntersectRegion(dpy, w->border_clip, w->border_clip, w->border_size);
+      if (w->border_size) {
+        XFixesIntersectRegion(dpy, w->border_clip, w->border_clip, w->border_size);
+      }
       XFixesSetPictureClipRegion(dpy, root_buffer, 0, 0, w->border_clip);
 
 #if HAS_NAME_WINDOW_PIXMAP


### PR DESCRIPTION
## Problem

When a window is destroyed while fading out (`-f`), it remains in the `win`
list with `w->destroyed` set until the fade completes. If `clip_changed` fires
during that period, `paint_all()` calls `border_size()` for a window whose X
resource no longer exists.

`border_size()` already documents this case and uses `set_ignore()` to suppress
the error from `XFixesCreateRegionFromWindow`. However, `set_ignore()` only
suppresses the error reply — the resulting value stored in `w->border_size` may
not refer to a valid region. Every subsequent paint cycle then calls
`XFixesIntersectRegion()` with that stale value, producing a `BadRegion` error
every frame until the fade completes.

## Reproduction

1. Start fastcompmgr with `-f` (fading enabled).
2. Open any window, then close it — a close-then-resize or a compositor
   repaint (e.g. moving another window) during the fade-out reliably triggers
   `clip_changed`.
3. Watch stderr.

## Before

```
X Error of failed request:  BadRegion (invalid Region parameter)
  Major opcode of failed request:  139 (XFIXES)
  Minor opcode of failed request:  12 (XFixesIntersectRegion)
  ...
```

Repeated every frame for the duration of the fade-out.

## After

No errors on stderr during or after window fade-out.

## Visual impact

None