### PR TITLE
Replace gettimeofday with clock_gettime(CLOCK_MONOTONIC)

### DIFF
--- a/cm-util.c
+++ b/cm-util.c
@@ -1,4 +1,2 @@
 
 #include "cm-util.h"
-
-time_t _program_start_secs = 0;

--- a/cm-util.h
+++ b/cm-util.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <sys/time.h>
+#include <time.h>
 #include <string.h>
-
-extern time_t _program_start_secs;
 
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)
@@ -18,9 +16,9 @@ do { ACCESS_ONCE(x) = (val); } while (0)
 
 static inline int
 get_time_in_milliseconds() {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return (tv.tv_sec-_program_start_secs) * 1000 + tv.tv_usec / 1000;
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (int)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 
 // normalize double to range 0-1


### PR DESCRIPTION
## Summary

Replaces `gettimeofday()` with `clock_gettime(CLOCK_MONOTONIC)` for all internal timers, fixing a correctness bug where system clock changes could cause fade timeouts and other timers to misbehave.

## Problem

`gettimeofday()` returns wall-clock time, which is vulnerable to NTP jumps or manual system clock changes. If the system clock is adjusted while fastcompmgr is running, internal timers (fade timeouts, configure debounce, etc.) can appear to run too fast or too slow, or even hang indefinitely.

## Solution

`clock_gettime(CLOCK_MONOTONIC)` is guaranteed to never go backwards and is not affected by system time changes. This is the correct clock for measuring elapsed time.

## Changes

- `cm-util.h` — replaces `gettimeofday()` with `clock_gettime(CLOCK_MONOTONIC)` in `get_time_in_milliseconds()`
- `cm-util.c` — removes the unused `_program_start_secs` variable (it was initialized to 0 and never set, so the subtraction was a no-op)
- `cm-util.h` — updates `#include <sys/time.h>` to `#include <time.h>`

## Scope

- `cm-util.h` and `cm-util.c` only
- `make clean && make` produces zero warnings, zero errors
- All existing call sites of `get_time_in_milliseconds()` are unaffected

## Impact

Correctness improvement: timers now behave correctly even when the system clock changes. No performance impact — `clock_gettime` is at least as fast as `gettimeofday` on modern Linux kernels.