### PR TITLE
Cache find_client_win results to avoid repeated XQueryTree scans

### DIFF
--- a/cm-window.h
+++ b/cm-window.h
@@ -85,6 +85,8 @@ typedef struct _win {
   unsigned long damage_sequence; /* sequence when damage was created */
   Bool destroyed;
   Bool paint_needed;
+  Bool client_id_resolved;
+  Window client_id;
   unsigned int left_width;
   unsigned int right_width;
   unsigned int top_width;

--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -910,7 +910,13 @@ get_frame_extents(win* w,
   *top = 0;
   *bottom = 0;
 
-  client_window = find_client_win(dpy, w->id);
+  if (w->client_id_resolved) {
+    client_window = w->client_id;
+  } else {
+    client_window = find_client_win(dpy, w->id);
+    w->client_id = client_window;
+    w->client_id_resolved = True;
+  }
   if (!client_window) {
     w->hidden_type = win_state_is_hidden( w->id) ? HIDDEN_YES : HIDDEN_NO;
     return;
@@ -966,7 +972,14 @@ win_paint_needed(win* w, CompRect* ignore_reg){
     case HIDDEN_UNKNOWN: {
       fprintf(stderr, "fastcompmgr warning: hidden state still unknown in "
                       "win_paint_needed: 0x%lx\n", w->id);
-      Window client_window = find_client_win(dpy, w->id);
+      Window client_window;
+      if (w->client_id_resolved) {
+        client_window = w->client_id;
+      } else {
+        client_window = find_client_win(dpy, w->id);
+        w->client_id = client_window;
+        w->client_id_resolved = True;
+      }
       if (!client_window) {
         // We already tried to find a client on add_win - give up for now.
         w->hidden_type = HIDDEN_IGNORE;
@@ -1253,6 +1266,8 @@ add_damage_if_hidden_changed(Window window, bool is_reparent_event) {
   }
   if(is_reparent_event){
     win_register_client_events(window);
+    w->client_id = 0; // invalidate cached client, will be re-resolved
+    w->client_id_resolved = False;
   }
   hiddentype hidden_type = win_state_is_hidden(window) ? HIDDEN_YES : HIDDEN_NO;
   // _NET_WM_STATE may change without altering _NET_WM_STATE_HIDDEN, so


### PR DESCRIPTION
## Summary

Caches `find_client_win()` results to eliminate repeated expensive `XQueryTree()` recursive scans on every frame.

## Problem

`find_client_win()` recursively calls `XQueryTree()` to locate the actual client window within a toplevel window hierarchy. This is expensive and currently called:
- on every call to `get_frame_extents()` (which reads `_NET_FRAME_EXTENTS`)
- in `win_paint_needed()` when the hidden state is still `HIDDEN_UNKNOWN`

For windows without a client window (e.g. `override_redirect` windows, or windows where the WM doesn't create a client), this results in a full recursive scan of the window hierarchy on every frame.

## Solution

Add `Bool client_id_resolved` and `Window client_id` fields to the `win` struct. The first call to `find_client_win()` stores the result; subsequent calls reuse the cached value.

The cache is invalidated on `ReparentNotify` events because the window hierarchy may have changed (e.g., when the window manager restarts and reparents windows).

## Changes

- `cm-window.h` — adds `client_id_resolved` and `client_id` fields to `win` struct
- `fastcompmgr.c` — uses the cache in `get_frame_extents()` and `win_paint_needed()`, invalidates on reparent in `add_damage_if_hidden_changed()`

## Scope

- `cm-window.h` and `fastcompmgr.c` only
- `make clean && make` produces zero warnings, zero errors
- Fields are zero-initialized by `calloc()` in `add_win()`

## Impact

Eliminates repeated `XQueryTree()` recursive scans for windows whose client window doesn't change. Most noticeable for windows without a client (e.g. `override_redirect` popups, menus), which previously triggered a full hierarchy scan on every frame.