### PR TITLE
Add CLI input validation for shadow radius and opacity

### DIFF
--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -532,6 +532,8 @@ make_shadow(Display *dpy, double opacity,
   unsigned char d;
   int x_diff;
   int opacity_int = (int)(opacity * 25);
+  if (opacity_int < 0) opacity_int = 0;
+  if (opacity_int > 25) opacity_int = 25;
 
   data = malloc(swidth * sheight * sizeof(unsigned char));
   if (!data) return 0;
@@ -2434,9 +2436,14 @@ main(int argc, char **argv) {
         break;
       case 'r':
         shadow_radius = atoi(optarg);
+        if (shadow_radius < 0 || shadow_radius > 100) {
+          fprintf(stderr, "Warning: shadow radius %d out of range, using 12\n",
+                  shadow_radius);
+          shadow_radius = 12;
+        }
         break;
       case 'o':
-        shadow_opacity = atof(optarg);
+        shadow_opacity = normalize_d(atof(optarg));
         break;
       case 'l':
         shadow_offset_x = atoi(optarg);


### PR DESCRIPTION
## Summary

Adds input validation for user-provided shadow radius and opacity values to prevent invalid inputs from causing crashes or undefined behavior.

## Changes

### Shadow radius (`-r` option)
- Clamped to `[0, 100]` with a warning message and fallback to `12` when out of range
- Prevents invalid Gaussian map sizes that could cause memory issues or crashes with extreme values

### Shadow opacity (`-o` option)
- Now uses `normalize_d()` (already present in the codebase) to clamp to `[0, 1]`
- Prevents invalid opacity values from reaching the rendering code

### Internal opacity in `make_shadow()`
- `opacity_int` (used as an index into `shadow_top` and `shadow_corner` lookup tables) is clamped to `[0, 25]`
- Guards against NaN or negative opacity inputs that could cause buffer under/overflow

## Scope

- Only `fastcompmgr.c` is touched
- `make clean && make` produces zero warnings, zero errors