### PR TITLE
Add XIOErrorHandler and make poll() robust against X11 disconnection

### DIFF
--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -2331,6 +2332,12 @@ check_paint(Display *dpy){
   }
 }
 
+static int
+xioerror_handler(Display *dpy) {
+  (void)dpy;
+  fprintf(stderr, "fastcompmgr: fatal: X11 connection lost (XIOError)\n");
+  return 0;  /* Xlib will exit(1) after this returns */
+}
 
 int
 main(int argc, char **argv) {
@@ -2474,6 +2481,7 @@ main(int argc, char **argv) {
   g_dpy = dpy;
 
   XSetErrorHandler(error);
+  XSetIOErrorHandler(xioerror_handler);
   if (synchronize) {
     XSynchronize(dpy, 1);
   }
@@ -2622,9 +2630,26 @@ main(int argc, char **argv) {
       if (!QLength(dpy)) {
         // TODO: check and re-implement fade time logic.
         int timeout = (configure_timer_started) ? 2 : fade_timeout();
-        if (unlikely(poll(&ufd, 1, timeout) == 0)) {
+        int poll_ret = poll(&ufd, 1, timeout);
+        if (unlikely(poll_ret == 0)) {
           check_paint(dpy);
            //   run_fades(dpy);
+          break;
+        }
+        if (poll_ret > 0) {
+          if (ufd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+            fprintf(stderr, "fastcompmgr: fatal: X11 connection closed (poll: %s%s%s)\n",
+                    (ufd.revents & POLLHUP) ? "HUP " : "",
+                    (ufd.revents & POLLERR) ? "ERR " : "",
+                    (ufd.revents & POLLNVAL) ? "NVAL " : "");
+            break;
+          }
+        }
+        if (poll_ret < 0) {
+          if (errno == EINTR) {
+            continue;
+          }
+          perror("fastcompmgr: poll failed");
           break;
         }
       }


### PR DESCRIPTION

## Summary

Adds an XIOErrorHandler and makes the poll() loop robust against X11 connection errors, fixing silent exits when the X server disconnects.

## Problem

Currently, when the X11 connection is lost (e.g. screen lock, VT switch, suspend/resume, or X server crash), fastcompmgr exits silently without any indication of what happened. This makes debugging very difficult — users just see the compositor "disappear".

Additionally, the poll() loop does not handle errors gracefully:
- `POLLHUP`/`POLLERR`/`POLLNVAL` on the X11 connection fd are ignored
- `EINTR` from poll() is not handled, causing the loop to break on signals
- Other poll errors are silently ignored

## Solution

### XIOErrorHandler
- Added `xioerror_handler()` that prints a clear "X11 connection lost (XIOError)" message to stderr before Xlib exits
- Registered via `XSetIOErrorHandler()` in `main()` right after `XSetErrorHandler()`

### poll() robustness
- Check `ufd.revents` for `POLLHUP`/`POLLERR`/`POLLNVAL` and log which condition triggered with a clear fatal message
- Handle `EINTR` from `poll()` correctly: `continue` the loop instead of breaking
- Other `poll()` errors are logged with `perror()`

## Scope

- Only `fastcompmgr.c` is touched
- `make clean && make` produces zero warnings, zero errors

## Impact

Stability/reliability improvement with no functional changes to the compositing logic. Makes diagnosing X11 disconnection issues much easier.