### PR TITLE
Cache root background atoms to avoid repeated XInternAtom calls

### DIFF
--- a/cm-root.c
+++ b/cm-root.c
@@ -110,12 +110,22 @@ Picture root_create_tile() {
   int res;
   const char* valid_pix_str;
 
+  static Atom root_background_atoms[2] = {None, None};
+  static bool atoms_cached = false;
+
+  if (!atoms_cached) {
+    for (p=0; root_background_props[p]; p++) {
+      root_background_atoms[p] = XInternAtom(g_dpy, root_background_props[p], False);
+    }
+    atoms_cached = true;
+  }
+
   pixmap = None;
 
   for (p=0; root_background_props[p]; p++) {
     prop = NULL;
     res = XGetWindowProperty(g_dpy, root,
-          XInternAtom(g_dpy, root_background_props[p], False),
+          root_background_atoms[p],
           0, 4, False, AnyPropertyType, &actual_type,
           &actual_format, &nitems, &bytes_after, &prop);
     if (res != Success || prop == NULL ){


### PR DESCRIPTION

## Summary

Caches root background atoms (`_XROOTPMAP_ID`, `_XSETROOT_ID`) on first use to eliminate repeated `XInternAtom()` calls every time the root background is painted.

## Problem

`root_create_tile()` calls `XInternAtom()` for each root background property every time it is invoked. Atoms are fixed X server-side identifiers that never change during a session, so this is an unnecessary round-trip.

## Solution

Cache the atoms in a static array on first call to `root_create_tile()` and reuse them on subsequent calls. A static `atoms_cached` flag ensures the cache is only populated once.

## Scope

- Only `cm-root.c` is touched
- `make clean && make` produces zero warnings, zero errors

## Impact

Eliminates 1–2 `XInternAtom()` calls per root background paint. Minor performance improvement, but trivial and correct.
