### PR TITLE
Use ring buffer size 2047 (power-of-2 - 1) for fast modulo

### DIFF
--- a/cm-event.c
+++ b/cm-event.c
@@ -44,6 +44,6 @@ void discard_ignore(Display *dpy, unsigned long sequence) {
 
 bool event_init()
 {
-  bufferInit(ignore_ringbuf, 2048, unsigned long);
+  bufferInit(ignore_ringbuf, 2047, unsigned long);
   return true;
 }


### PR DESCRIPTION

## Summary

Changes the event-ignore ring buffer size from 2048 to 2047, enabling the compiler to optimize modulo operations into bitwise AND.

## Problem

The ring buffer macros use modulo operations for index wrapping:
```
(index + 1) % (size + 1)
```

With size = 2048, `size + 1 = 2049`, which is not a power of two. The compiler must emit a general modulo instruction (division).

## Solution

With size = 2047, `size + 1 = 2048 = 2^11`. The compiler can optimize modulo by a power of two into a bitwise AND: `& 2047`. This is faster on all architectures, especially those without hardware divide.

## Scope

- Only `cm-event.c` is touched (one constant change)
- `make clean && make` produces zero warnings, zero errors

## Impact

Micro-optimization in the event-ignore tracking path. No functional change.
