### PR TITLE
Fix zombie window leak by passing win pointer directly to finish_destroy_win

### DIFF
--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -1886,61 +1886,64 @@ circulate_win(Display *dpy, XCirculateEvent *ce) {
 }
 
 static void
-finish_destroy_win(Display *dpy, Window id) {
-  win **prev, *w;
+finish_destroy_win(Display *dpy, win *w) {
+  win **prev;
 
-  for (prev = &list; (w = *prev); prev = &w->next) {
-    if (w->id == id && w->destroyed) {
-      finish_unmap_win(dpy, w);
+  if (!w || !w->destroyed) return;
+
+  finish_unmap_win(dpy, w);
+
+  for (prev = &list; *prev; prev = &(*prev)->next) {
+    if ((*prev) == w) {
       *prev = w->next;
-
-      if (w->alpha_pict) {
-        XRenderFreePicture(dpy, w->alpha_pict);
-        w->alpha_pict = None;
-      }
-
-      if (w->alpha_border_pict) {
-        XRenderFreePicture(dpy, w->alpha_border_pict);
-        w->alpha_border_pict = None;
-      }
-
-      if (w->shadow_pict) {
-        XRenderFreePicture(dpy, w->shadow_pict);
-        w->shadow_pict = None;
-      }
-
-      /* fix leak, from freedesktop repo */
-      if (w->shadow) {
-        XRenderFreePicture (dpy, w->shadow);
-        w->shadow = None;
-      }
-
-      if (w->damage != None) {
-        set_ignore(dpy, NextRequest(dpy));
-        XDamageDestroy(dpy, w->damage);
-        w->damage = None;
-      }
-
-      cleanup_fade(dpy, w);
-
-      if (w->border_clip) {
-        XFixesDestroyRegion(dpy, w->border_clip);
-        w->border_clip = None;
-      }
-      if(w->extents){
-        XFixesDestroyRegion(dpy, w->extents);
-        w->extents = None;
-      }
-      free(w);
       break;
     }
   }
+
+  if (w->alpha_pict) {
+    XRenderFreePicture(dpy, w->alpha_pict);
+    w->alpha_pict = None;
+  }
+
+  if (w->alpha_border_pict) {
+    XRenderFreePicture(dpy, w->alpha_border_pict);
+    w->alpha_border_pict = None;
+  }
+
+  if (w->shadow_pict) {
+    XRenderFreePicture(dpy, w->shadow_pict);
+    w->shadow_pict = None;
+  }
+
+  /* fix leak, from freedesktop repo */
+  if (w->shadow) {
+    XRenderFreePicture (dpy, w->shadow);
+    w->shadow = None;
+  }
+
+  if (w->damage != None) {
+    set_ignore(dpy, NextRequest(dpy));
+    XDamageDestroy(dpy, w->damage);
+    w->damage = None;
+  }
+
+  cleanup_fade(dpy, w);
+
+  if (w->border_clip) {
+    XFixesDestroyRegion(dpy, w->border_clip);
+    w->border_clip = None;
+  }
+  if(w->extents){
+    XFixesDestroyRegion(dpy, w->extents);
+    w->extents = None;
+  }
+  free(w);
 }
 
 #if HAS_NAME_WINDOW_PIXMAP
 static void
 destroy_callback(Display *dpy, win *w) {
-  finish_destroy_win(dpy, w->id);
+  finish_destroy_win(dpy, w);
 }
 #endif
 
@@ -1960,7 +1963,7 @@ destroy_win(Display *dpy, Window id, Bool fade) {
   } else
 #endif
   {
-    finish_destroy_win(dpy, id);
+    finish_destroy_win(dpy, w);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a memory leak where destroyed windows accumulate indefinitely because `finish_destroy_win()` cannot find them via ID lookup.

## Problem

`finish_destroy_win()` searched for the window by ID using a linear scan that required `w->destroyed == True`. However, `find_win()` (used by `destroy_win()` and other callers) filters out destroyed windows:

```c
win* find_win(Window id) {
  for (w = list; w; w = w->next) {
    if (w->id == id && !w->destroyed)  // <-- filters out destroyed!
      return w;
  }
}
```

When `destroy_win()` marks a window as `destroyed` and then calls `finish_destroy_win()`, the latter scans the list looking for `w->destroyed == True`. But if `find_win()` was called in between (or if the window is accessed again), the destroyed window is skipped. More importantly, `finish_destroy_win()` itself searches by ID and requires `w->destroyed`, but since the caller already has the `win*` pointer, the search is redundant and fragile.

The result: zombie `win` structs accumulate in the window list forever, causing memory growth and eventual slowdown over long sessions.

## Solution

Change `finish_destroy_win()` to accept a `win*` pointer directly instead of a `Window` ID. The callers already have the pointer:
- `destroy_win()` finds it via `find_win()` before marking destroyed
- `destroy_callback()` receives it as an argument

This eliminates the problematic ID lookup entirely.

## Scope

- Only `fastcompmgr.c` is touched
- Function signature change + two caller updates
- `make clean && make` produces zero warnings, zero errors

## Note

The list unlink logic remains a linear scan (to be replaced by O(1) unlink once the doubly-linked list PR is merged).