### PR TITLE
Bypass broken fade-out path to eliminate double-free recursion

### DIFF
--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -1937,31 +1937,16 @@ finish_destroy_win(Display *dpy, Window id) {
   }
 }
 
-#if HAS_NAME_WINDOW_PIXMAP
-static void
-destroy_callback(Display *dpy, win *w) {
-  finish_destroy_win(dpy, w->id);
-}
-#endif
-
 static void
 destroy_win(Display *dpy, Window id, Bool fade) {
   win *w = find_win(id);
+  (void)fade;
 
   if (w) w->destroyed = True;
 
   set_paint_ignore_region_dirty();
 
-#if HAS_NAME_WINDOW_PIXMAP
-  if (w && w->pixmap && fade && win_type_fade[w->window_type]) {
-    set_fade(dpy, w, w->opacity * 1.0 / OPAQUE,
-      0.0, fade_out_step, destroy_callback,
-      False, True);
-  } else
-#endif
-  {
-    finish_destroy_win(dpy, id);
-  }
+  finish_destroy_win(dpy, id);
 }
 
 #if 0


### PR DESCRIPTION
## Summary

Bypasses the broken fade-out path in `destroy_win()` to eliminate a recursive double-free crash.

## Problem

The fade-out path is broken:

1. `destroy_win()` calls `set_fade()` with `destroy_callback` as the callback
2. When the fade completes, `dequeue_fade()` calls `destroy_callback()`
3. `destroy_callback()` calls `finish_destroy_win()`
4. `finish_destroy_win()` calls `cleanup_fade()`
5. `cleanup_fade()` calls `dequeue_fade()` again
6. `dequeue_fade()` calls `destroy_callback()` again on the same `win*`
7. `finish_destroy_win()` runs a second time on the freed/already-destroyed `win*`, causing a double-free / use-after-free

## Solution

Since fading is already known to be broken and not maintained, the safest fix is to bypass the fade-out path entirely. `destroy_win()` now always calls `finish_destroy_win()` directly, and the unused `destroy_callback` is removed.

This eliminates the recursive double-free while keeping the code simpler. Note: fade-in (set_fade on map) is unaffected and continues to work if enabled.

## Scope

- Only `fastcompmgr.c` is touched
- `make clean && make` produces zero warnings, zero errors

## Impact

Eliminates a crash path during window destruction. No functional change for users who do not use fading (the default).