### PR TITLE
Remove dead shadow_pict field from win struct

### DIFF
--- a/cm-window.h
+++ b/cm-window.h
@@ -69,7 +69,6 @@ typedef struct _win {
   Picture picture;
   Picture alpha_pict;
   Picture alpha_border_pict;
-  Picture shadow_pict;
   XserverRegion border_size;
   XserverRegion extents;
   Picture shadow;

--- a/fastcompmgr.c
+++ b/fastcompmgr.c
@@ -1613,11 +1613,6 @@ determine_mode(Display *dpy, win *w) {
     w->alpha_border_pict = None;
   }
 
-  if (w->shadow_pict) {
-    XRenderFreePicture(dpy, w->shadow_pict);
-    w->shadow_pict = None;
-  }
-
   if (w->a.class == InputOnly) {
     format = 0;
   } else {
@@ -1712,7 +1707,6 @@ add_win(Display *dpy, Window id, Window prev) {
 
   new->alpha_pict = None;
   new->alpha_border_pict = None;
-  new->shadow_pict = None;
   new->border_size = None;
   new->extents = None;
   new->shadow = None;
@@ -1902,11 +1896,6 @@ finish_destroy_win(Display *dpy, Window id) {
       if (w->alpha_border_pict) {
         XRenderFreePicture(dpy, w->alpha_border_pict);
         w->alpha_border_pict = None;
-      }
-
-      if (w->shadow_pict) {
-        XRenderFreePicture(dpy, w->shadow_pict);
-        w->shadow_pict = None;
       }
 
       /* fix leak, from freedesktop repo */


### PR DESCRIPTION

## Summary

Removes the unused `shadow_pict` field from the `win` struct, shrinking it by one pointer with no functional change.

## Problem

The `shadow_pict` field in the `win` struct is set to `None` on creation and never used anywhere in the codebase. It is a leftover from earlier development that serves no purpose.

## Solution

Remove the field and all assignments/frees associated with it.

## Scope

- `cm-window.h` — removes `Picture shadow_pict` field
- `fastcompmgr.c` — removes three references (init in `add_win`, free in `determine_mode`, free in `finish_destroy_win`)
- `make clean && make` produces zero warnings, zero errors

## Impact

Shrinks the `win` struct by 8 bytes on 64-bit platforms. No functional change.
