### PR TITLE
Fix intersection calculation bug in rect_paint_needed

### DIFF
--- a/comp_rect.c
+++ b/comp_rect.c
@@ -42,9 +42,9 @@ bool rect_paint_needed(CompRect* ignore_reg, CompRect* reg){
 
     // calculate the intersection rect.
     short x1 = (ignore_reg->x1 > reg->x1) ? ignore_reg->x1 : reg->x1;
-    short x2 = (ignore_reg->x2 < reg->x2) ? ignore_reg->x1 : reg->x1;
+    short x2 = (ignore_reg->x2 < reg->x2) ? ignore_reg->x2 : reg->x2;
     short y1 = (ignore_reg->y1 > reg->y1) ? ignore_reg->y1 : reg->y1;
-    short y2 = (ignore_reg->y2 < reg->y2) ? ignore_reg->y1 : reg->y1;
+    short y2 = (ignore_reg->y2 < reg->y2) ? ignore_reg->y2 : reg->y2;
     short w = x2 - x1;
     short h = y2 - y1;
 


### PR DESCRIPTION

## Summary

Fixes two copy-paste errors in the intersection rectangle calculation that could cause windows to be incorrectly skipped during painting.

## Problem

The intersection rectangle calculation in `rect_paint_needed()` had two copy-paste errors:

```c
x2 = (ignore_reg->x2 < reg->x2) ? ignore_reg->x1 : reg->x1;  // should be x2
y2 = (ignore_reg->y2 < reg->y2) ? ignore_reg->y1 : reg->y1;  // should be y2
```

This produced incorrect intersection dimensions, which could cause `w*h` to be negative or wrong, leading to the ignore region being computed incorrectly and windows that should be painted being skipped.

## Solution

Correct the ternary operators to use `x2` and `y2` respectively:

```c
x2 = (ignore_reg->x2 < reg->x2) ? ignore_reg->x2 : reg->x2;
y2 = (ignore_reg->y2 < reg->y2) ? ignore_reg->y2 : reg->y2;
```

## Scope

- Only `comp_rect.c` is touched (2 lines)
- `make clean && make` produces zero warnings, zero errors

## Impact

Fixes a correctness bug in the occlusion culling logic. On certain window layouts (overlapping windows with specific positions), this could cause visible windows to not be painted.
